### PR TITLE
transfer rules directly to sigconverter

### DIFF
--- a/streamlit/pages/1_Create_A_New_Sigma_Rule.py
+++ b/streamlit/pages/1_Create_A_New_Sigma_Rule.py
@@ -9,6 +9,8 @@ import streamlit as st
 import uuid
 import uuid
 import yaml
+import base64
+from urllib.parse import quote_plus
 from streamlit_ace import st_ace, KEYBINDINGS, LANGUAGES, THEMES
 
 
@@ -496,9 +498,11 @@ with tab1:
             validate_bool = True
 
     with col3:
+        # base64 and url encode the yaml output
+        encoded_yaml_output = quote_plus(base64.b64encode(yaml_output.encode('utf-8')).decode('utf-8'))
         st.link_button(
             "⏳ Convert Using SigConverter",
-            url="https://sigconverter.io",
+            url="https://sigconverter.io/#rule=" + encoded_yaml_output,
         )
 
     if generate_bool:

--- a/streamlit/pages/2_Update_An_Existing_Sigma_Rule.py
+++ b/streamlit/pages/2_Update_An_Existing_Sigma_Rule.py
@@ -9,6 +9,8 @@ import ntpath
 import openai
 import streamlit as st
 import yaml
+import base64
+from urllib.parse import quote_plus
 from streamlit_ace import st_ace, KEYBINDINGS, LANGUAGES, THEMES
 
 
@@ -543,9 +545,11 @@ with tab1:
             validate_bool = True
 
     with col3:
+        # base64 and url encode the yaml output
+        encoded_yaml_output = quote_plus(base64.b64encode(yaml_output.encode('utf-8')).decode('utf-8'))
         st.link_button(
             "⏳ Convert Using SigConverter",
-            url="https://sigconverter.io",
+            url="https://sigconverter.io/#rule=" + encoded_yaml_output,
         )
 
     if generate_bool:


### PR DESCRIPTION
This PR uses the latest update from sigconverter to provide the rule as a parameter in the URL. Now a click on the "Convert using SigConverter" button will open a new tab with the rule pre-loaded so that no copy and paste is needed.